### PR TITLE
Allow for 'import' in webpack config

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports = function(source) {
 
   var stylusOptions = this.options.stylus || {};
   options.use = options.use || stylusOptions.use || [];
+  options.import = options.import || stylusOptions.import || [];
 
   var styl = stylus(source, options);
   var paths = [path.dirname(options.filename)];


### PR DESCRIPTION
Without this line, lines 49-52 never are executed. I think there is something bigger here going on, and I can investigate further, but this does resolve being able to define files that you'd like imported into all stylus files (i.e. nib) so that you don't need @import 'nib' all over the place.