### PR TITLE
pass through sourceMap option to stylus, and also inherit source-map option from devtool

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,9 +19,12 @@ module.exports = function(source) {
   options.use = options.use || stylusOptions.use || [];
   options.import = options.import || stylusOptions.import || [];
 
-  if (options.sourceMap) {
-    options.sourcemap = { comment: true, inline: true };
+  if (options.sourceMap != null) {
+    options.sourcemap = options.sourceMap;
     delete options.sourceMap;
+  }
+  else if (this.sourceMap) {
+    options.sourcemap = { comment: false };
   }
 
   var styl = stylus(source, options);


### PR DESCRIPTION
This solves two issues I ran into.

The first is that I wanted to pass sourcemap options directly to stylus for greater control over the output. This allows that, while defaulting to `stylus-loader?sourceMap => sourcemap = true`. 

The second is that when using css-loader and ExtractTextPlugin, you get two source map URLs in the output, one of which is to a nonexistant compiled .css file with the same name as your main stylus require. Since css-loader already inherits the source-map option from your webpack config, it seems that would make sense here too, and avoids the duplicate sourcemap issue, leaving only [name].css.map and a URL reference to it.

I think this is a possibly breaking change from 1.0.0 in the sense that `stylus-loader?sourceMap` currently results in `sourcemap = { comment: true, inline: true }`. I believe that inlining source maps is probably not the desired default behavior, but if you want to avoid the BC break I understand and can revise the PR. What do you think?