### PR TITLE
Resolve manual imports with PathCache.resolvers

### DIFF
--- a/lib/pathcache.js
+++ b/lib/pathcache.js
@@ -41,6 +41,8 @@ PathCache.createFromFile = resolveFileDeep;
 // Create a list of ways to resolve paths.
 PathCache.resolvers = resolvers;
 
+PathCache.resolvers.reduce = reduceResolvers;
+
 // Lookup the path in this cache.
 PathCache.prototype.find = function(path, filename) {
   if (this.contexts[filename] && this.contexts[filename][path]) {
@@ -125,6 +127,13 @@ function resolvers(options, webpackResolver) {
   ];
 }
 
+function reduceResolvers(resolvers, context, path) {
+  return when
+    .reduce(resolvers, function(result, resolver) {
+      return result ? result : resolver(context, path);
+    }, undefined);
+}
+
 // Run resolvers on one path and return an object with the found path under a
 // key of the original path.
 //
@@ -134,10 +143,7 @@ function resolvers(options, webpackResolver) {
 // returns an object
 //   {'a/file': {path: ['node_modules/a/file'], index: true}}
 function resolveOne(resolvers, context, path) {
-  return when
-    .reduce(resolvers, function(result, resolver) {
-      return result ? result : resolver(context, path);
-    }, undefined)
+  return reduceResolvers(resolvers, context, path)
     .then(function(result) {
       result = typeof result === 'string' ? [result] : result;
       result = Array.isArray(result) ? {path: result, index: false} : result;

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -102,4 +102,56 @@ describe("basic", function() {
 		(typeof css).should.be.eql("string");
 		css.should.be.eql('@import url(http://fonts.googleapis.com/css?family=Open+Sans:400,700,400italic);\n');
 	});
+	it("imports files listed in option argument", function() {
+		var css = require(
+			"!raw-loader!..?import[]=urls.styl!./fixtures/stylus.styl"
+		);
+		(typeof css).should.be.eql("string");
+		css.should.match(/body/);
+		css.should.match(/\.imported-stylus/);
+	});
+	it("imports files listed in option argument stylus paths style", function() {
+		var css = require(
+			"!raw-loader" +
+			"!..?import[]=in-paths.styl&paths[]=" + __dirname + "/fixtures/paths" +
+			"!./fixtures/stylus.styl"
+		);
+		(typeof css).should.be.eql("string");
+		css.should.match(/\.other/);
+		css.should.match(/\.imported-stylus/);
+	});
+	it("imports files listed in option argument webpack style", function() {
+		var css = require(
+			"!raw-loader!..?import[]=~fakenib!./fixtures/stylus.styl"
+		);
+		(typeof css).should.be.eql("string");
+		css.should.match(/\.not-real-nib/);
+		css.should.match(/\.imported-stylus/);
+	});
+	it("imports files listed in option argument and deps", function() {
+		var css = require(
+			"!raw-loader!..?import[]=import-styl.styl!./fixtures/basic.styl"
+		);
+		(typeof css).should.be.eql("string");
+		css.should.match(/\.imported-stylus/);
+		css.should.match(/a\.button/);
+	});
+	it("imports files listed in option argument and paths deps", function() {
+		var css = require(
+			"!raw-loader" +
+			"!..?import[]=import-paths.styl&paths[]=" + __dirname + "/fixtures/paths" +
+			"!./fixtures/basic.styl"
+		);
+		(typeof css).should.be.eql("string");
+		css.should.match(/\.other/);
+		css.should.match(/a\.button/);
+	});
+	it("imports files listed in option argument and webpack deps", function() {
+		var css = require(
+			"!raw-loader!..?import[]=import-webpack.styl!./fixtures/basic.styl"
+		);
+		(typeof css).should.be.eql("string");
+		css.should.match(/\.other/);
+		css.should.match(/a\.button/);
+	});
 });


### PR DESCRIPTION
Manual imports was overlooked a while ago when PathCache was added. Now with PathCache manual imports can be found like any other import and their dependencies can found and their path cached as well.