### PR TITLE
Fixed dependency lookup for transformed sources

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ module.exports = function(source) {
   });
 
   var boundResolvers = PathCache.resolvers(options, this.resolve);
-  PathCache.createFromFile(boundResolvers, {}, options.filename)
+  PathCache.createFromFile(boundResolvers, {}, source, options.filename)
     .then(function(importPathCache) {
       // CachedPathEvaluator will use this PathCache to find its dependencies.
       options.cache = importPathCache;

--- a/index.js
+++ b/index.js
@@ -74,7 +74,9 @@ module.exports = function(source) {
     .then(function(importPathCache) {
       // CachedPathEvaluator will use this PathCache to find its dependencies.
       options.cache = importPathCache;
-      importPathCache.allDeps().forEach(self.addDependency);
+      importPathCache.allDeps().forEach(function(f) {
+        self.addDependency(path.normalize(f));
+      });
 
       styl.render(function(err, css) {
         if (err) done(err);

--- a/lib/pathcache.js
+++ b/lib/pathcache.js
@@ -160,11 +160,15 @@ function resolveMany(resolvers, context, paths) {
 }
 
 // Load a file at fullPath, resolve all of it's imports and report for those.
-function resolveFileDeep(resolvers, contexts, fullPath) {
+function resolveFileDeep(resolvers, contexts, source, fullPath) {
   contexts = contexts || {};
-  var nestResolve = resolveFileDeep.bind(null, resolvers, contexts);
+  var nestResolve = resolveFileDeep.bind(null, resolvers, contexts, null);
   var context = path.dirname(fullPath);
-  return readFile(fullPath, 'utf8')
+  return when
+    .try(function() {
+      if (typeof source === 'string') { return source; }
+      return readFile(fullPath, 'utf8');
+    })
     .then(listImports)
     .then(resolveMany.bind(null, resolvers, context))
     .then(function(newPaths) {


### PR DESCRIPTION
Dependency lookup failed if the stylus source being compiled was different from what was written on disk (for example, if the source was already passed through a loader)