### PR TITLE
provide require-styled @imports and @requires for stylus

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ stylus: {
 }
 ```
 
+### Query Parameters
+
+You can pass the built-in stylus paramters via the loader configration.
+
+There is an extra parameter for webpack:
+
+If you set the value for the `requireSyntax` to __true__, paths which doesn't
+start with `.` or `/` will be automatically prepended with a `~` (if they don't have `~` already).
+This makes stylus `@imports` and `@require` behave like a webpack `require()`.
+
 ## Install
 
 `npm install stylus-loader --save-dev`

--- a/lib/pathcache.js
+++ b/lib/pathcache.js
@@ -113,6 +113,12 @@ function resolvers(options, webpackResolver) {
       // Follow the webpack stylesheet idiom of '~path' meaning a path in a
       // modules folder and a unprefixed 'path' meaning a relative path like
       // './path'.
+      // except if you using requireSyntax, in this case you can omit ~
+      if (options.requireSyntax) {
+        if (/^[^.~\/]/.test(path)) {
+         path = '~'+path;
+        }
+      }
       path = loaderUtils.urlToRequest(path, options.root);
       // First try with a '.styl' extension.
       return whenWebpackResolver(context, path + '.styl')

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/shama/stylus-loader/issues"
   },
   "peerDependencies": {
-    "stylus": "0.x",
+    "stylus": "0.x"
   },
   "dependencies": {
     "loader-utils": "^0.2.9",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
   "bugs": {
     "url": "https://github.com/shama/stylus-loader/issues"
   },
+  "peerDependencies": {
+    "stylus": "0.x",
+  },
   "dependencies": {
     "loader-utils": "^0.2.9",
-    "stylus": "^0.49.3",
     "when": "~3.6.x"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull request allows to write stylus `@import` and `@require` statements without the ~ to load from the module and root directory.
This should not break anything because you need to enable this feature it via the query.

So this PR don't force users to use some special syntax for module relative include paths, instead they can use a common way to do that.