### PR TITLE
Visit call expression to pick up use calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - "iojs"
   - "0.12"
   - "0.10"
+sudo: false
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/lib/listimports.js
+++ b/lib/listimports.js
@@ -26,6 +26,20 @@ ImportVisitor.prototype.visitRoot = function(block){
   return block;
 };
 
+ImportVisitor.prototype.visitExpression = function(expr) {
+  for (var i = 0; i < expr.nodes.length; ++i) {
+    this.visit(expr.nodes[i]);
+  }
+  return expr;
+};
+
+ImportVisitor.prototype.visitCall = function(fn) {
+  if (fn.name === 'use') {
+    this.importPaths.push(fn.args.first.string);
+  }
+  return fn;
+};
+
 ImportVisitor.prototype.visitBlock = ImportVisitor.prototype.visitRoot;
 
 // Returns a list of paths that given source imports.

--- a/test/all.js
+++ b/test/all.js
@@ -1,1 +1,2 @@
 require("./basic.test.js");
+require("./listimport.test.js");

--- a/test/fixtures/imports/import.styl
+++ b/test/fixtures/imports/import.styl
@@ -1,0 +1,1 @@
+@import 'local-file.styl';

--- a/test/fixtures/imports/require.styl
+++ b/test/fixtures/imports/require.styl
@@ -1,0 +1,1 @@
+@require 'local-file.styl';

--- a/test/fixtures/imports/use.styl
+++ b/test/fixtures/imports/use.styl
@@ -1,0 +1,1 @@
+use('neat-functions.js')

--- a/test/helpers/stylus-import-loader.js
+++ b/test/helpers/stylus-import-loader.js
@@ -1,0 +1,5 @@
+var listImports = require('../../lib/listimports');
+
+module.exports = function(content) {
+  return 'module.exports = ' + JSON.stringify(listImports(content, {cache: {}})) + ';';
+};

--- a/test/listimport.test.js
+++ b/test/listimport.test.js
@@ -1,0 +1,20 @@
+var should = require("should");
+
+describe("listimport", function() {
+
+  it("recognizes @import", function() {
+    var imports = require("!./helpers/stylus-import-loader.js!./fixtures/imports/import.styl");
+    imports.should.be.eql(['local-file.styl']);
+  });
+
+  it("recognizes @require", function() {
+    var imports = require("!./helpers/stylus-import-loader.js!./fixtures/imports/require.styl");
+    imports.should.be.eql(['local-file.styl']);
+  });
+
+  it("recognizes use()", function() {
+    var imports = require("!./helpers/stylus-import-loader.js!./fixtures/imports/use.styl");
+    imports.should.be.eql(['neat-functions.js']);
+  });
+
+});


### PR DESCRIPTION
Picking up use calls in listimports we can pass those paths through PathCache and to webpack to list as dependencies.

This is an incomplete solution to #63. On the surface it fulfills watching a file mentioned by use. But it stops there. If that file further required another js file, that required file would not be watched.

Its a kind of funky too. Because this then lists a js file in the imports to PathCache, PatchCache will try to list imports of that js file, but it'll currently treat it as a stylus file, leading to an error, which listimports ignores as currently it leaves stylus to present errors as it'll do a better job. Since stylus treats the use('file') as js this ends up being fine but its kind of funky.