### PR TITLE
Run plugins before resolving imports and files. Close #69

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,9 @@ module.exports = function(source) {
   options.Evaluator = CachedPathEvaluator;
 
   var stylusOptions = this.options.stylus || {};
-  options.use = options.use || stylusOptions.use || [];
+  // Instead of assigning to options, we run them manually later so their side effects apply earlier for
+  // resolving paths.
+  var use = options.use || stylusOptions.use || [];
   options.import = options.import || stylusOptions.import || [];
   options.define = options.define || stylusOptions.define || [];
 
@@ -99,6 +101,9 @@ module.exports = function(source) {
     resolvers: boundResolvers,
     readFile: readFile,
   };
+
+  // Use plugins here so that resolve related side effects can be used while we resolve imports.
+  use.forEach(styl.use, styl);
 
   when
     // Resolve manual imports like @import files.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   ],
   "scripts": {
     "test": "testem ci",
-    "test-dev": "testem -l firefox"
+    "test-dev": "testem -l firefox",
+    "test-one": "testem ci -l firefox",
+    "test-build": "webpack --config test/webpack.config.js --output-path test/tmp --output-file bundle.js"
   },
   "author": "Kyle Robinson Young <kyle@dontkry.com> (http://dontkry.com)",
   "license": "MIT",

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -110,6 +110,11 @@ describe("basic", function() {
 		css.should.match(/body/);
 		css.should.match(/\.imported-stylus/);
 	});
+	it("imports files in a directory included by a plugin", function() {
+		var css = require("!raw-loader!..!./fixtures/import-include.styl");
+		(typeof css).should.be.eql("string");
+		css.should.match(/.in-include/);
+	});
 	it("imports files listed in option argument stylus paths style", function() {
 		var css = require(
 			"!raw-loader" +

--- a/test/fixtures/import-include.styl
+++ b/test/fixtures/import-include.styl
@@ -1,0 +1,1 @@
+@import 'in-include'

--- a/test/fixtures/include/in-include.styl
+++ b/test/fixtures/include/in-include.styl
@@ -1,0 +1,3 @@
+.in-include {
+  content: 'plugin';
+}

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -1,9 +1,18 @@
 // Just run "webpack-dev-server"
+
+var path = require('path');
+
 function plugin() {
   return function(style) {
     style.define('add', function(a, b) {
       return a.operate('+', b);
     });
+  };
+}
+
+function includePlugin() {
+  return function(style) {
+    style.include(path.join(__dirname, 'fixtures', 'include'));
   };
 }
 
@@ -13,7 +22,7 @@ module.exports = {
 	resolve: {
 		extensions: ["", ".js", ".css", ".styl"]
 	},
-  stylus: {
-    use: [plugin()]
-  }
+	stylus: {
+		use: [plugin(), includePlugin()]
+	}
 };


### PR DESCRIPTION
Plugins are run as the first step in stylus rendering. Instead of passing plugins and running them there, we'll run them ourselves so when we resolve imports include side effects from those plugins take count. This lets depended on files take advantage of the paths those plugins include.