### PR TITLE
add sourcesContent to returned source map

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,8 +145,12 @@ module.exports = function(source) {
       // var paths = importPathCache.origins;
 
       styl.render(function(err, css) {
-        if (err) done(err);
-        else done(null, css, styl.sourcemap);
+        if (err) {
+          done(err);
+        } else {
+          styl.sourcemap.sourcesContent = [source];
+          done(null, css, styl.sourcemap);
+        }
       });
     })
     .catch(done);


### PR DESCRIPTION
When chained with other loaders, e.g. `css?sourceMap!postcss?...!stylus?sourceMap`, the displayed source map in the browser ends up being `null`, because the map passed down from `stylus-loader` doesn't contain the `sourcesContent` property.

Adding it allows the maps to be properly chained.