### PR TITLE
Remove stylus from direct dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,11 @@ stylus: {
 
 ## Install
 
-`npm install stylus-loader --save-dev`
+`npm install stylus-loader stylus --save-dev`
+
+**Important**: in order to have ability use any `stylus` package version,
+it won't be installed automatically. So it's required to
+add it to `package.json` along with `stylus-loader`.
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "loader-utils": "^0.2.9",
-    "stylus": "^0.52.4",
     "when": "~3.6.x"
   },
   "devDependencies": {
@@ -37,6 +36,7 @@
     "raw-loader": "~0.5.1",
     "should": "~4.6.1",
     "style-loader": "^0.12.2",
+    "stylus": ">=0.52.4",
     "testem": "^0.8.3",
     "webpack": "^1.9.8",
     "webpack-dev-server": "~1.7.0"


### PR DESCRIPTION
Since stylus-loader is not really depends on particular stylus
package version, it makes sense to remove it from the dependencies,
so a user could manually manage stylus version (upgrade, lock etc).