### PR TITLE
normalize resolved paths to fix watch/hmr on windows

### DIFF
--- a/lib/pathcache.js
+++ b/lib/pathcache.js
@@ -95,7 +95,11 @@ function resolvers(options, webpackResolver) {
       if (!/.styl$/.test(path)) {
         path += '.styl';
       }
-      return utils.find(path, options.paths, options.filename);
+
+      var found = utils.find(path, options.paths, options.filename)
+      if (found) {
+        return normalizePaths(found);
+      }
     },
     // Stylus's normal resolver for node_modules packages. Cannot locate paths
     // inside a package.
@@ -105,9 +109,10 @@ function resolvers(options, webpackResolver) {
       if (!path) {
         return null;
       }
+
       var found = utils.lookupIndex(path, options.paths, options.filename);
       if (found) {
-        return {path: found, index: true};
+        return {path: normalizePaths(found), index: true};
       }
     },
     // Fallback to resolving with webpack's configured resovler.
@@ -260,4 +265,11 @@ function partialRight(fn) {
   return function() {
     return fn.apply(this, slice(arguments).concat(args));
   };
+}
+
+function normalizePaths(paths) {
+  for(var i in paths) {
+    paths[i] = path.normalize(paths[i]);
+  }
+  return paths;
 }


### PR DESCRIPTION
hi - i think i've fixed the issue that @AwesomeJerry and @MikaelStenstrand were experiencing here: https://github.com/webpack/webpack/issues/1345

That is HMR not working on imported .styl files on Windows.

The problem was that the changed files were not being purged from webpack's CachedInputFileSystem.

readFile was being called with forward slashes causing webpack to store it in that state for comparison later on when file changes were detected. When webpack detected the changes it used backslashes instead so it never purged the file from it's cache.

The fix was just to normalize the resolved paths that were returned from Stylus.