### PR TITLE
Add cached sources to sourcemap

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,9 @@ module.exports = function(source) {
           done(err);
         } else {
           if (styl.sourcemap) {
-            styl.sourcemap.sourcesContent = [source];
+            styl.sourcemap.sourcesContent = styl.sourcemap.sources.map(function (file) {
+              return importPathCache.sources[path.resolve(file)]
+            });
           }
           done(null, css, styl.sourcemap);
         }


### PR DESCRIPTION
Currently only the main, top-level source is added to the sourcemap, resulting in empty maps for any included files. This PR adds the missing sources from the cache. Fixes #56 