### PR TITLE
Instructions to enable nib

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ stylus: {
 }
 ```
 
+#### Using nib with stylus
+
+The easiest way of enabling `nib` is to import it in the stylus options:
+
+```js
+stylus: {
+  use: [require('nib')()],
+  import: ['~nib/lib/nib/index.styl']
+}
+```
+
+where `~` resolves to `node_modules/`
+
 ## Install
 
 `npm install stylus-loader --save-dev`


### PR DESCRIPTION
I had a difficult time tracking down the instructions to use `nib`. Figured it would be good to explicitly include in the readme.