### PR TITLE
Added option to disable CachedPathEvaluator

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function(source) {
   var done = this.async();
   var options = loaderUtils.parseQuery(this.query);
   options.filename = options.filename || this.resourcePath;
-  options.Evaluator = CachedPathEvaluator;
+  options.Evaluator = options.pathCache !== false && CachedPathEvaluator;
 
   var stylusOptions = this.options.stylus || {};
   // Instead of assigning to options, we run them manually later so their side effects apply earlier for


### PR DESCRIPTION
This pull request adds option to disable `CachedPathEvaluator` while https://github.com/shama/stylus-loader/issues/44 is still awaiting proper patch.