### PR TITLE
Replace this.filename PathCache lookup with dirname

### DIFF
--- a/lib/evaluator.js
+++ b/lib/evaluator.js
@@ -142,8 +142,9 @@ CachedPathEvaluator.prototype.visitImport = function(imported) {
   * THIS IS THE ONLY BLOCK THAT DIFFERS FROM THE ACTUAL STYLUS IMPLEMENTATION. *
   *****************************************************************************/
   // Lookup
-  found = this.cache.find(path, this.filename);
-  index = this.cache.isIndex(path, this.filename);
+  var dirname = this.paths[this.paths.length - 1];
+  found = this.cache.find(path, dirname);
+  index = this.cache.isIndex(path, dirname);
   if (!found) {
     found = utils.find(path, this.paths, this.filename);
     if (!found) {

--- a/lib/pathcache.js
+++ b/lib/pathcache.js
@@ -25,9 +25,9 @@ function PathCache(contexts, sources, imports) {
   // Non relative paths are simpler and looked up in this as a fallback
   // to this.context.
   this.simpleContext = {};
-  for (var filename in this.contexts) {
-    for (var path in this.contexts[filename]) {
-      this.simpleContext[path] = this.contexts[filename][path];
+  for (var dirname in this.contexts) {
+    for (var path in this.contexts[dirname]) {
+      this.simpleContext[path] = this.contexts[dirname][path];
     }
   }
 }
@@ -44,25 +44,25 @@ PathCache.resolvers = resolvers;
 PathCache.resolvers.reduce = reduceResolvers;
 
 // Lookup the path in this cache.
-PathCache.prototype.find = function(path, filename) {
-  if (this.contexts[filename] && this.contexts[filename][path]) {
-    return this.contexts[filename][path].path;
+PathCache.prototype.find = function(path, dirname) {
+  if (this.contexts[dirname] && this.contexts[dirname][path]) {
+    return this.contexts[dirname][path].path;
   } else if (this.simpleContext[path]) {
     return this.simpleContext[path].path;
   } else if (/.styl$/.test(path)) {
     // A user can specify @import 'something.styl' but if they specify
     // @import 'something' stylus adds .styl, we drop that here to see if we
     // looked for it without .styl.
-    return this.find(path.replace(/.styl$/, ''), filename);
+    return this.find(path.replace(/.styl$/, ''), dirname);
   } else {
     return undefined;
   }
 };
 
 // Return if the path in this cache is an index file.
-PathCache.prototype.isIndex = function(path, filename) {
-  if (this.contexts[filename] && this.contexts[filename][path]) {
-    return this.contexts[filename][path].index;
+PathCache.prototype.isIndex = function(path, dirname) {
+  if (this.contexts[dirname] && this.contexts[dirname][path]) {
+    return this.contexts[dirname][path].index;
   } else {
     return undefined;
   }
@@ -71,10 +71,10 @@ PathCache.prototype.isIndex = function(path, filename) {
 // Return an array of all imports the original file depends on.
 PathCache.prototype.allDeps = function() {
   var deps = [];
-  for (var filename in this.contexts) {
-    for (var path in this.contexts[filename]) {
-      if (this.contexts[filename][path]) {
-        deps = deps.concat(this.contexts[filename][path].path);
+  for (var dirname in this.contexts) {
+    for (var path in this.contexts[dirname]) {
+      if (this.contexts[dirname][path]) {
+        deps = deps.concat(this.contexts[dirname][path].path);
       }
     }
   }
@@ -205,7 +205,7 @@ function resolveFileDeep(helpers, parentCache, source, fullPath) {
     .then(function(newPaths) {
       // Contexts are the full path since multiple could be in the same folder
       // but different deps.
-      contexts[fullPath] = newPaths;
+      contexts[context] = merge(contexts[context] || {}, newPaths);
       return when.map(Object.keys(newPaths), function(key) {
         var found = newPaths[key] && newPaths[key].path;
         if (found) {
@@ -252,6 +252,14 @@ function ensureFunctionsSource(sources, source) {
 }
 
 var slice = Array.prototype.slice.call.bind(Array.prototype.slice);
+
+function merge(a, b) {
+  var key;
+  for (key in b) {
+    a[key] = b[key];
+  }
+  return a;
+}
 
 function partial(fn) {
   var args = slice(arguments, 1);

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -159,4 +159,10 @@ describe("basic", function() {
 		css.should.match(/\.other/);
 		css.should.match(/a\.button/);
 	});
+  it("imports the right file based on context", function() {
+    var css = require("!raw-loader!..!./fixtures/context");
+    (typeof css).should.be.eql("string");
+    css.should.match(/\.a-color/);
+    css.should.match(/\.b-color/);
+  });
 });

--- a/test/fixtures/context/a/color.styl
+++ b/test/fixtures/context/a/color.styl
@@ -1,0 +1,3 @@
+.a-color {
+  color: #aaa;
+}

--- a/test/fixtures/context/a/index.styl
+++ b/test/fixtures/context/a/index.styl
@@ -1,0 +1,1 @@
+@import 'color.styl';

--- a/test/fixtures/context/b/color.styl
+++ b/test/fixtures/context/b/color.styl
@@ -1,0 +1,3 @@
+.b-color {
+  color: #bbb;
+}

--- a/test/fixtures/context/b/index.styl
+++ b/test/fixtures/context/b/index.styl
@@ -1,0 +1,1 @@
+@import 'color.styl';

--- a/test/fixtures/context/index.styl
+++ b/test/fixtures/context/index.styl
@@ -1,0 +1,2 @@
+@import 'a';
+@import 'b';


### PR DESCRIPTION
As #44 brings up, PathCache returns the same resolved path for two different contexts (folders). PathCache stores the resolved paths under the file that requested them. The right node could be looked up to find this filepath when the Evaluator is looking for the resolved path but it may be better to work the way utils.find does, with the context that contains the item importing the targets, not its filepath. This path is stored as the last member to this.paths, so this change passes that to PathCache and updates PathCache to take a directory path.

I've included a test that passes with the fix commit.

@cspotcode pointed out the problem well in #44.

> Specifically, this.paths is being used by Stylus's resolver to find files relative to the @import-ing file. The dirname of the @import-ing .styl file is appended to this.paths, but CachedPathEvaluator and PathCache aren't using it.

I can't believe I didn't make this connection when I originally wrote PathCache and CachedPathEvaluator.