### PR TITLE
Move stylus from devDependencies to dependencies object. Fix #107

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "loader-utils": "^0.2.9",
+    "stylus": ">=0.52.4",
     "when": "~3.6.x"
   },
   "devDependencies": {
@@ -36,7 +37,6 @@
     "raw-loader": "~0.5.1",
     "should": "~4.6.1",
     "style-loader": "^0.12.2",
-    "stylus": ">=0.52.4",
     "testem": "^0.8.3",
     "webpack": "^1.9.8",
     "webpack-dev-server": "~1.7.0"


### PR DESCRIPTION
Move stylus from `devDependencies` to `dependencies` object.

@shama could you bump package version to patch (`2.0.1`) please? `npm version patch && npm publish`