### PR TITLE
Declare a peer dependency on stylus

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "webpack": "^1.9.8",
     "webpack-dev-server": "~1.7.0"
   },
+  "peerDependencies": {
+    "stylus": ">=0.52.4"
+  },
   "keywords": [
     "webpack",
     "loader",


### PR DESCRIPTION
Users who upgrade to 2.0.0 who don't have stylus as a dependency will see errors when running webpack.