### PR TITLE
fix Node 6.x path erros for this.dest

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = function(source) {
   this.cacheable && this.cacheable();
   var done = this.async();
   var options = loaderUtils.parseQuery(this.query);
+  options.dest = options.dest || '';
   options.filename = options.filename || this.resourcePath;
   options.Evaluator = CachedPathEvaluator;
 
@@ -122,7 +123,7 @@ module.exports = function(source) {
         .reduce(boundResolvers, path.dirname(options.filename), filename)
         .then(function(paths) { return carry.concat(paths); });
     }, [])
-    // Resolve dependencies of 
+    // Resolve dependencies of
     .then(function(paths) {
       paths.forEach(styl.import.bind(styl));
       paths.forEach(self.addDependency);


### PR DESCRIPTION
In Node 6.x, all functions in the `path` module will throw an Error if the argument path is `undefined`. Previously it would silently return an empty string. This causes `stylus-loader` to error out due to `stylus`' sourcemap module trying to determine file path on `this.dest`.

This fix ensures `this.dest` is always a string and should preserve the same behavior as in Node 5.