### PR TITLE
fix: bind stylus renderer include function to itself

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ module.exports = function(source) {
         styl.define(defineName, value[defineName]);
       }
     } else if (key === 'include') {
-      needsArray(value).forEach(styl.include);
+      needsArray(value).forEach(styl.include.bind(styl));
     } else if (key === 'import') {
       needsArray(value).forEach(function(stylusModule) {
         manualImports.push(stylusModule);


### PR DESCRIPTION
This commit forces the `forEach` callback to be bound to the stylus renderer instead of the global context.

Fixes #124 