### PR TITLE
Throw this error when `use` is only a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ module.exports = function(source) {
   };
 
   // Use plugins here so that resolve related side effects can be used while we resolve imports.
-  use.forEach(styl.use, styl);
+  (Array.isArray(use) ? use : [use]).forEach(styl.use, styl);
 
   when
     // Resolve manual imports like @import files.


### PR DESCRIPTION
```sh
./~/css-loader!./~/stylus-loader!./src/xxxx/index.styl
Module build failed: TypeError: use.forEach is not a function
    at Object.module.exports (F:\xxxx\node_modules\stylus-loader\index.js:117:7)
 @ ./src/xxxx/index.styl 4:14-124 13:2-17:4 14:20-130
```

happen on

```js
  //...
  stylus: {
    include: paths,
    use: function(render) { //... }
  }
```