### PR TITLE
Make PathCache stylus resolving a little more like stylus standalone

### DIFF
--- a/lib/pathcache.js
+++ b/lib/pathcache.js
@@ -96,7 +96,8 @@ function resolvers(options, webpackResolver) {
         path += '.styl';
       }
 
-      var found = utils.find(path, options.paths, options.filename)
+      var paths = options.paths.concat(context);
+      var found = utils.find(path, paths, options.filename)
       if (found) {
         return normalizePaths(found);
       }
@@ -110,7 +111,8 @@ function resolvers(options, webpackResolver) {
         return null;
       }
 
-      var found = utils.lookupIndex(path, options.paths, options.filename);
+      var paths = options.paths.concat(context);
+      var found = utils.lookupIndex(path, paths, options.filename);
       if (found) {
         return {path: normalizePaths(found), index: true};
       }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -164,5 +164,6 @@ describe("basic", function() {
     (typeof css).should.be.eql("string");
     css.should.match(/\.a-color/);
     css.should.match(/\.b-color/);
+    css.should.not.match(/\.c-color/);
   });
 });

--- a/test/fixtures/context/color.styl
+++ b/test/fixtures/context/color.styl
@@ -1,0 +1,3 @@
+.c-color {
+  color: #ccc;
+}


### PR DESCRIPTION
When running stylus outside of stylus-loader it synchronously resolves
files while evaluating. While it evaluates as it imports a file, it
adds the context (its directory path) of that file to the stylus
instance's `paths` array. `paths` is used to look up relative paths by
iterating from the end of the array to the start.

`stylus-loader` since we added PathCache, left paths alone. This was an
oversight that leads to relative paths not working (unless stylus can't
find it and we fall back to resolving with webpack). `stylus-loader`
can't modify paths like stylus does since it can potentially resolve
multiple dependencies at once. We can concat and create separate
`paths` copies. This change does that by appending the context variable
that for stylus resolving PathCache was otherwise throwing away.

This doesn't accurately follow stylus yet. If you had a tree of stylus
files depending on each other `paths` would have a layer for each
context as it goes deeper.

So this change just represents the last context and not the contexts in
between. This should hopefully cover 99% of relative path use.

@exogen @ryan-roemer @ryanisinallofus I think this should resolve what you all are doing with `stylus-relative-loader`. #123