### PR TITLE
Add `preferPathResolver` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ stylus: {
 
 where `~` resolves to `node_modules/`
 
+### Prefer webpack resolving
+
+`stylus-loader` currently prefers resolving paths with stylus's resovling utilities and then falling back to webpack when it can't find files. Use the `preferPathResolver` option with the value `'webpack'` to swap this. This has the benefit of using webpack's async resolving instead of stylus's sync resolving. If you have a lot of dependencies in your stylus files this'll let those dependencies be found in parallel.
+
+```js
+styus: {
+  preferPathResolver: 'webpack',
+}
+```
+
 ## Install
 
 `npm install stylus-loader stylus --save-dev`

--- a/lib/pathcache.js
+++ b/lib/pathcache.js
@@ -96,7 +96,8 @@ function resolvers(options, webpackResolver) {
         path += '.styl';
       }
 
-      var found = utils.find(path, options.paths, options.filename)
+      var paths = options.paths.concat(context);
+      var found = utils.find(path, paths, options.filename)
       if (found) {
         return normalizePaths(found);
       }
@@ -110,7 +111,8 @@ function resolvers(options, webpackResolver) {
         return null;
       }
 
-      var found = utils.lookupIndex(path, options.paths, options.filename);
+      var paths = options.paths.concat(context);
+      var found = utils.lookupIndex(path, paths, options.filename);
       if (found) {
         return {path: normalizePaths(found), index: true};
       }

--- a/lib/pathcache.js
+++ b/lib/pathcache.js
@@ -88,53 +88,69 @@ PathCache.prototype.allDeps = function() {
 function resolvers(options, webpackResolver) {
   var evaluator = new Evaluator(nodes.null, options);
   var whenWebpackResolver = whenNodefn.lift(webpackResolver);
-  return [
-    // Stylus's normal resolver for single files.
-    function(context, path) {
-      // Stylus adds .styl to paths for normal "paths" lookup if it isn't there.
-      if (!/.styl$/.test(path)) {
-        path += '.styl';
-      }
 
-      var paths = options.paths.concat(context);
-      var found = utils.find(path, paths, options.filename)
-      if (found) {
-        return normalizePaths(found);
-      }
-    },
-    // Stylus's normal resolver for node_modules packages. Cannot locate paths
-    // inside a package.
-    function(context, path) {
-      // Stylus calls the argument name. If it exists it should match the name
-      // of a module in node_modules.
-      if (!path) {
-        return null;
-      }
-
-      var paths = options.paths.concat(context);
-      var found = utils.lookupIndex(path, paths, options.filename);
-      if (found) {
-        return {path: normalizePaths(found), index: true};
-      }
-    },
-    // Fallback to resolving with webpack's configured resovler.
-    function(context, path) {
-      // Follow the webpack stylesheet idiom of '~path' meaning a path in a
-      // modules folder and a unprefixed 'path' meaning a relative path like
-      // './path'.
-      path = loaderUtils.urlToRequest(path, options.root);
-      // First try with a '.styl' extension.
-      return whenWebpackResolver(context, path + '.styl')
-        // If the user adds ".styl" to resolve.extensions, webpack can find
-        // index files like stylus but it uses all of webpack's configuration,
-        // by default for example the module could be web_modules.
-        .catch(function() { return whenWebpackResolver(context, path); })
-        .catch(function() { return null; })
-        .then(function(result) {
-          return Array.isArray(result) && result[1] && result[1].path || result
-        });
+  // Stylus's normal resolver for single files.
+  var stylusFile = function(context, path) {
+    // Stylus adds .styl to paths for normal "paths" lookup if it isn't there.
+    if (!/.styl$/.test(path)) {
+      path += '.styl';
     }
-  ];
+
+    var paths = options.paths.concat(context);
+    var found = utils.find(path, paths, options.filename)
+    if (found) {
+      return normalizePaths(found);
+    }
+  };
+
+  // Stylus's normal resolver for node_modules packages. Cannot locate paths
+  // inside a package.
+  var stylusIndex = function(context, path) {
+    // Stylus calls the argument name. If it exists it should match the name
+    // of a module in node_modules.
+    if (!path) {
+      return null;
+    }
+
+    var paths = options.paths.concat(context);
+    var found = utils.lookupIndex(path, paths, options.filename);
+    if (found) {
+      return {path: normalizePaths(found), index: true};
+    }
+  };
+
+  // Fallback to resolving with webpack's configured resovler.
+  var webpackResolve = function(context, path) {
+    // Follow the webpack stylesheet idiom of '~path' meaning a path in a
+    // modules folder and a unprefixed 'path' meaning a relative path like
+    // './path'.
+    path = loaderUtils.urlToRequest(path, options.root);
+    // First try with a '.styl' extension.
+    return whenWebpackResolver(context, path + '.styl')
+      // If the user adds ".styl" to resolve.extensions, webpack can find
+      // index files like stylus but it uses all of webpack's configuration,
+      // by default for example the module could be web_modules.
+      .catch(function() { return whenWebpackResolver(context, path); })
+      .catch(function() { return null; })
+      .then(function(result) {
+        return Array.isArray(result) && result[1] && result[1].path || result
+      });
+  };
+
+  if (options.preferPathResolver === 'webpack') {
+    return [
+      webpackResolve,
+      stylusFile,
+      stylusIndex
+    ];
+  }
+  else {
+    return [
+      stylusFile,
+      stylusIndex,
+      webpackResolve
+    ];
+  }
 }
 
 function reduceResolvers(resolvers, context, path) {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -164,5 +164,6 @@ describe("basic", function() {
     (typeof css).should.be.eql("string");
     css.should.match(/\.a-color/);
     css.should.match(/\.b-color/);
+    css.should.not.match(/\.c-color/);
   });
 });

--- a/test/fixtures/context/color.styl
+++ b/test/fixtures/context/color.styl
@@ -1,0 +1,3 @@
+.c-color {
+  color: #ccc;
+}


### PR DESCRIPTION
Depends on #137

Let `stylus-loader` users opt for webpack resolving before stylus. This
can allow for most common stylus files to be found in parallel through
webpack's async resolver instead of blocking on file IO with stylus's
sync resolver.