### PR TITLE
add support to define *paths* through options

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ module.exports = function(source) {
   options.include = options.include || stylusOptions.include || [];
   options.set = options.set || stylusOptions.set || {};
   options.define = options.define || stylusOptions.define || {};
+  options.paths = options.paths || stylusOptions.paths;
 
   if (options.sourceMap != null) {
     options.sourcemap = options.sourceMap;


### PR DESCRIPTION
For now, paths could only passed through query, it should also be allowed to pass it through global *stylusOptions*.